### PR TITLE
changed logic of publishing to pypi

### DIFF
--- a/.github/workflows/publish-to-test-pypi-and-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi-and-pypi.yaml
@@ -23,15 +23,19 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
+
+      # Pushing to PyPI must be done consciously since it requires changing of version. Hence only tagged releases
+      # should be pushed.
+      # Runs when something is pushed to develop branch with tag
       - name: Publish distribution 📦 to Test PyPI
-        # Any release with tags need not be published to Test PYPI , as it would have already been published and may lead to error.
-        if: startsWith(github.ref, 'refs/tags') != true
+        if: startsWith(github.ref, 'refs/tags')  && github.ref == 'refs/heads/develop'
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+      # Runs when master branch is tagged
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags') && github.ref == 'refs/heads/master'
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Every branch to be tagged with a release version to be pushed to PyPI.